### PR TITLE
added pagination to the list and search API's

### DIFF
--- a/customers/api.py
+++ b/customers/api.py
@@ -2,6 +2,7 @@ from .models import Customer, Prescription
 from rest_framework import viewsets, permissions, status
 from rest_framework.views import APIView
 from rest_framework.exceptions import ValidationError
+from optic_invoicer_api.custom_cursor_pagination import CustomCursorPagination
 from .serializers import CustomerSerializer, PrescriptionSerializer
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -60,4 +61,17 @@ class CustomerSearchView(APIView):
             customers = queryset.filter(email__icontains=email)
 
         serializer = CustomerSerializer(customers, many=True)
+
+
+        
+        # Apply custom cursor pagination
+        paginator = CustomCursorPagination()
+        page = paginator.paginate_queryset(queryset, request)
+        
+        if page is not None:
+            serializer = CustomerSerializer(page, many=True)
+            return paginator.get_paginated_response(serializer.data)
+
+        serializer = CustomerSerializer(customers, many=True)
         return Response(serializer.data)
+    

--- a/invoices/api.py
+++ b/invoices/api.py
@@ -37,7 +37,6 @@ class InvoiceViewSet(viewsets.ModelViewSet):
             if taxable_param is not None:   
                 is_taxable = taxable_param.lower() in ['true', '1', 'yes']
                 queryset = queryset.filter(is_taxable=is_taxable)
-            print("getting")
             return queryset
         return Invoice.objects.none()  # Return an empty queryset if conditions aren't met
 

--- a/optic_invoicer_api/custom_cursor_pagination.py
+++ b/optic_invoicer_api/custom_cursor_pagination.py
@@ -1,0 +1,20 @@
+from rest_framework.pagination import CursorPagination, _positive_int
+from rest_framework.settings import api_settings
+
+class CustomCursorPagination(CursorPagination):
+    page_size = api_settings.PAGE_SIZE
+    ordering = '-created_on'
+    page_size_query_param = 'page_size'  # This allows the client to set the page size
+
+    def get_page_size(self, request):
+        if self.page_size_query_param:
+            try:
+                return _positive_int(
+                    request.query_params[self.page_size_query_param],
+                    strict=True,
+                    cutoff=self.max_page_size
+                )
+            except (KeyError, ValueError):
+                pass
+
+        return self.page_size

--- a/optic_invoicer_api/settings.py
+++ b/optic_invoicer_api/settings.py
@@ -64,7 +64,9 @@ INSTALLED_APPS = [
     'drf_yasg'  
 ]
 REST_FRAMEWORK ={
-    'DEFAULT_AUTHENTICATION_CLASSES': ('knox.auth.TokenAuthentication',)
+    'DEFAULT_AUTHENTICATION_CLASSES': ('knox.auth.TokenAuthentication',),
+    'DEFAULT_PAGINATION_CLASS': 'optic_invoicer_api.custom_cursor_pagination.CustomCursorPagination',
+    'PAGE_SIZE': 10  # Default page size
 }
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/organizations/api.py
+++ b/organizations/api.py
@@ -137,6 +137,9 @@ class OrganizationListView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     
     def get(self, request):
+        if not self.request.user.is_superuser:
+            raise serializer.ValidationError("Only superusers can view an organization.")
+
         organizations = Organization.objects.all()
         serializer = ListOrganizationStaffSerializer(organizations, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Updated the apis to list and search with cursor based pagination now the response will be

{
    "next": "http://127.0.0.1:8000/api/customer/?cursor=cD0yMDIzLTExLTE1KzA0JTNBNDYlM0EzNS40NjcxMjMlMkIwMCUzQTAw&page_size=3",
    "previous": null,
    "results": [ ------- list of items ------]
}

calling the next or the previous cursor link will give the next or prervious set of data
